### PR TITLE
refactor: translate the key "Enter"

### DIFF
--- a/wordle-it.js
+++ b/wordle-it.js
@@ -1347,7 +1347,7 @@ this.wordle = this.wordle || {}, this.wordle.bundle = function(e) {
                                   var t = document.createElement("game-icon");
                                   t.setAttribute("icon", "backspace"), a.textContent = "", a.appendChild(t), a.classList.add("one-and-a-half")
                               }
-                              "↵" == e && (a.textContent = "enter", a.classList.add("one-and-a-half"))
+                              "↵" == e && (a.textContent = "invio", a.classList.add("one-and-a-half"))
                           } else(a = is.content.cloneNode(!0).firstElementChild).classList.add(1 === e.length ? "half" : "one");
                           s.appendChild(a)
                       })), e.$keyboard.appendChild(s)


### PR DESCRIPTION
Use "Invio" as the translation for the button's text.

I'm not sure how to generate the built version of the site: I don't see a command in the README.
However I checked the event handlers and the click is handled by processing the `data-key` attribute so I don't think that changing the text will break anything.

Resolves #18.