### PR TITLE
Usa sempre il fuso orario italiano

### DIFF
--- a/wordle-it.js
+++ b/wordle-it.js
@@ -966,9 +966,19 @@ this.wordle = this.wordle || {}, this.wordle.bundle = function(e) {
   var Ra = new Date(2022, 0, 3, 0, 0, 0, 0);
 
   function $a(e, a) {
-      var s = new Date(e),
-          t = new Date(a).setHours(0, 0, 0, 0) - s.setHours(0, 0, 0, 0);
-      return Math.floor(t / 864e5)
+    var s = new Date(e);
+    var tempDate = new Date(a);
+
+    try {
+      const convertedDate = new Date(tempDate.toLocaleString('en-US', { timeZone: "Europe/Rome" }));
+      tempDate = convertedDate;
+      console.log('convertedDate: ', convertedDate);
+    } catch (error) {
+      console.error('Error converting to Italian timezone: ', error);
+    }
+
+    var t = tempDate.setHours(0, 0, 0, 0) - s.setHours(0, 0, 0, 0);
+    return Math.floor(t / 864e5);
   }
 
   function Pa(e) {


### PR DESCRIPTION
Ho modificato il calcolo dell'offset di tempo così che venga sempre usata l'ora attuale in Italia e non quella locale. Questo permetto di sfidarsi tra amici e parenti senza preoccuparsi di fusi orari, in modo che tutti ricevano la stessa parola (quella "in Italia").

Sto preprarando una PR che sistemi anche eventuali problemi di ora legale e giorni saltati, se ben accetto.

Fixes https://github.com/pietroppeter/wordle-it/issues/99.
Fixes https://github.com/pietroppeter/wordle-it/issues/90.
Fixes https://github.com/pietroppeter/wordle-it/issues/73.
Fixes https://github.com/pietroppeter/wordle-it/issues/57.