### PR TITLE
Fix bug cambio ora legale nel calcolo del giorno

### DIFF
--- a/test/dst-regression.js
+++ b/test/dst-regression.js
@@ -1,0 +1,87 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { spawnSync } = require('child_process');
+
+const bundlePaths = [
+  path.join(__dirname, '..', 'wordle-it.js'),
+  path.join(__dirname, 'wordle-it.js')
+];
+
+function loadDayDiff(bundlePath) {
+  const source = fs.readFileSync(bundlePath, 'utf8');
+  const match = source.match(/function \$a\(e, a\) \{[\s\S]*?return Math\.floor\(\(r - o\) \/ 864e5\)[\s\S]*?\}/);
+
+  if (!match) {
+    throw new Error(`Could not locate $a() in ${bundlePath}`);
+  }
+
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(`${match[0]}; this.dayDiff = $a;`, context);
+  return context.dayDiff;
+}
+
+function runCases() {
+  const cases = [
+    {
+      label: 'Europe/Rome spring forward',
+      start: [2026, 2, 29, 12],
+      end: [2026, 2, 30, 12],
+      expected: 1
+    },
+    {
+      label: 'Europe/Rome fall back',
+      start: [2026, 9, 25, 12],
+      end: [2026, 9, 26, 12],
+      expected: 1
+    },
+    {
+      label: 'America/New_York spring forward',
+      start: [2026, 2, 8, 12],
+      end: [2026, 2, 9, 12],
+      expected: 1
+    },
+    {
+      label: 'America/New_York fall back',
+      start: [2026, 10, 1, 12],
+      end: [2026, 10, 2, 12],
+      expected: 1
+    }
+  ];
+
+  for (const bundlePath of bundlePaths) {
+    const dayDiff = loadDayDiff(bundlePath);
+
+    for (const testCase of cases) {
+      const start = new Date(...testCase.start);
+      const end = new Date(...testCase.end);
+      assert.strictEqual(
+        dayDiff(start, end),
+        testCase.expected,
+        `${path.basename(bundlePath)} failed: ${testCase.label}`
+      );
+    }
+  }
+}
+
+if (process.argv[2] === '--case') {
+  runCases();
+  process.exit(0);
+}
+
+for (const timeZone of ['Europe/Rome', 'America/New_York']) {
+  const result = spawnSync(process.execPath, [__filename, '--case'], {
+    env: { ...process.env, TZ: timeZone },
+    stdio: 'pipe',
+    encoding: 'utf8'
+  });
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status || 1);
+  }
+}
+
+console.log('DST regression checks passed.');

--- a/test/wordle-it.js
+++ b/test/wordle-it.js
@@ -967,8 +967,10 @@ this.wordle = this.wordle || {}, this.wordle.bundle = function(e) {
 
   function $a(e, a) {
       var s = new Date(e),
-          t = new Date(a).setHours(0, 0, 0, 0) - s.setHours(0, 0, 0, 0);
-      return Math.floor(t / 864e5)
+          t = new Date(a),
+          o = Date.UTC(s.getFullYear(), s.getMonth(), s.getDate()),
+          r = Date.UTC(t.getFullYear(), t.getMonth(), t.getDate());
+      return Math.floor((r - o) / 864e5)
   }
 
   function Pa(e) {

--- a/wordle-it.js
+++ b/wordle-it.js
@@ -967,8 +967,10 @@ this.wordle = this.wordle || {}, this.wordle.bundle = function(e) {
 
   function $a(e, a) {
       var s = new Date(e),
-          t = new Date(a).setHours(0, 0, 0, 0) - s.setHours(0, 0, 0, 0);
-      return Math.floor(t / 864e5)
+          t = new Date(a),
+          o = Date.UTC(s.getFullYear(), s.getMonth(), s.getDate()),
+          r = Date.UTC(t.getFullYear(), t.getMonth(), t.getDate());
+      return Math.floor((r - o) / 864e5)
   }
 
   function Pa(e) {


### PR DESCRIPTION
Questa PR corregge un bug che, nei giorni del passaggio tra ora solare e ora legale, poteva far comparire al gioco la parola del giorno precedente.

Il problema stava nel modo in cui veniva calcolata la differenza tra due date: il codice si basava sui millisecondi tra due mezzanotti locali, ma nei giorni da 23 o 25 ore quel calcolo non è affidabile.

La fix evita il problema usando solo la data di calendario, tramite `Date.UTC(...)`, invece del tempo locale in millisecondi. In questo modo il cambio di giorno viene gestito correttamente anche durante i passaggi DST.

La PR include:
- la correzione del calcolo in wordle-it.js
- l'allineamento della stessa logica in test/wordle-it.js
- un test di regressione dedicato ai cambi tra ora legale e ora solare

Spero possiate accogliere questa PR: in famiglia ci sfidiamo giornalmente e due volte l'anno ~questo bug ci rompe la striscia di vittorie~ ci tocca saltare la sfida😄 